### PR TITLE
Db copy updates

### DIFF
--- a/ensembl_dbcopy/admin.py
+++ b/ensembl_dbcopy/admin.py
@@ -19,7 +19,7 @@ from django.db.models import Count
 from django.db.models import F
 from django.utils.html import format_html
 
-from ensembl_dbcopy.forms import SubmitForm
+from ensembl_dbcopy.forms import SubmitForm, GroupForm
 from ensembl_dbcopy.models import Host, Group, RequestJob
 from ensembl_production.admin import SuperUserAdmin
 
@@ -113,7 +113,8 @@ class UserFilter(SimpleListFilter):
 
 @admin.register(Group)
 class GroupItemAdmin(admin.ModelAdmin, SuperUserAdmin):
-    form = GroupRecordForm
+    form = GroupForm #GroupRecordForm
+    add_form_template = "admin/dbcopy/multiselect.html" 
     list_display = ('host_id', 'group_name')
     fields = ('host_id', 'group_name')
     search_fields = ('host_id', 'group_name')

--- a/ensembl_dbcopy/forms.py
+++ b/ensembl_dbcopy/forms.py
@@ -17,7 +17,22 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 
-from ensembl_dbcopy.models import RequestJob, Group, Host
+from ensembl_dbcopy.models import RequestJob, Group, Host, NAME_CHOICES_GROUP
+
+
+class GroupForm(forms.ModelForm):
+    class Meta:
+        model = Group
+        exclude = ('group_id',)
+    group_name = forms.MultipleChoiceField(choices=NAME_CHOICES_GROUP, required=True, label="Group Name")
+
+    def __init__(self, *args, **kwargs):
+        super(GroupForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_id = 'group-job-form'
+        self.helper.form_class = 'group-job-form'
+        self.helper.form_method = 'post'
+        self.helper.add_input(Submit('submit', 'Submit'))
 
 
 class SubmitForm(forms.ModelForm):

--- a/ensembl_dbcopy/models.py
+++ b/ensembl_dbcopy/models.py
@@ -156,7 +156,7 @@ class Host(models.Model):
     port = models.IntegerField()
     mysql_user = models.CharField(max_length=64)
     virtual_machine = models.CharField(max_length=255, blank=True, null=True)
-    mysqld_file_owner = models.CharField(max_length=128)
+    mysqld_file_owner = models.CharField(max_length=128, null=True, blank=True)
 
     class Meta:
         db_table = 'host'

--- a/ensembl_dbcopy/templates/admin/dbcopy/detail.html
+++ b/ensembl_dbcopy/templates/admin/dbcopy/detail.html
@@ -6,6 +6,7 @@
       <a href="{% url 'admin:ensembl_dbcopy_requestjob_changelist' %}" class="btn btn-secondary" role="button">Back to list</a>
       <a href="{% url 'admin:ensembl_dbcopy_requestjob_add' %}" class="btn btn-secondary" role="button">Submit New Copy</a>
       <a href="{% url 'ensembl_dbcopy:reset_failed_jobs' original.job_id %}" class="btn btn-secondary" role="button">Reset failed jobs</a>
+      <a href="{% url 'admin:ensembl_dbcopy_requestjob_change' original.job_id %}" class="btn btn-secondary" role="button">Refresh</a>
     </div>
     <div class="p-3 my-3 border">
       <div class="row">

--- a/ensembl_dbcopy/templates/admin/dbcopy/multiselect.html
+++ b/ensembl_dbcopy/templates/admin/dbcopy/multiselect.html
@@ -1,0 +1,22 @@
+{% extends 'admin/change_form.html' %}
+{% load static %}
+{% load crispy_forms_tags %}
+{% block content %}
+
+  <div class="container-fluid">
+    <div class="p-3 my-3 border">
+      {% block submit %}
+       <form action="{% url 'ensembl_dbcopy:group_choice' %}"  method="POST">
+       {% csrf_token %}
+       {% crispy adminform.form adminform.form.helper %}
+      </form>
+      {% endblock submit %}
+    </div>
+  </div>
+
+{% endblock content %}
+{% block extrastyle %}
+    {{ block.super }}
+    <link href="{% static "css/db_copy.css" %}" rel="stylesheet"/>
+{% endblock %}
+

--- a/ensembl_dbcopy/urls.py
+++ b/ensembl_dbcopy/urls.py
@@ -13,10 +13,11 @@
 """
 from django.urls import path
 
-from .views import reset_failed_jobs
+from .views import reset_failed_jobs, group_choice
 
 app_name = 'ensembl_dbcopy'
 
 urlpatterns = [
     path('reset_failed_jobs/<uuid:job_id>', reset_failed_jobs, name='reset_failed_jobs'),
+    path('add', group_choice, name='group_choice'),
 ]

--- a/ensembl_dbcopy/views.py
+++ b/ensembl_dbcopy/views.py
@@ -15,7 +15,7 @@ from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
 
-from ensembl_dbcopy.models import RequestJob
+from ensembl_dbcopy.models import RequestJob, Group, Host
 
 
 def reset_failed_jobs(request, *args, **kwargs):
@@ -28,3 +28,20 @@ def reset_failed_jobs(request, *args, **kwargs):
                   args=[obj.job_id])
     messages.success(request, "All the failed jobs for %s have been successfully reset" % job_id)
     return redirect(url)
+
+def group_choice(request, *args, **kwargs):
+
+    host_id = request.POST.get("host_id")
+    host_id = Host.objects.get(auto_id=host_id)
+    for each_group in request.POST.getlist('group_name'):
+        grp = Group.objects.filter(group_name=[str(each_group)], host_id=request.POST.get("host_id"))
+        if len(grp) > 0 :
+            continue
+        new_group = Group()
+        new_group.group_name = each_group
+        new_group.host_id = host_id #Host.objects.get(auto_id=host_id)
+        new_group.save()
+
+    url = reverse('admin:ensembl_dbcopy_group_changelist')
+    return redirect(url)
+


### PR DESCRIPTION
Host:mysqld_owner to be turn nullable (not mandatory anymore after all)
Update Permission scheme interface to allow multiple group selection for one host.
Auto refresh or add button to autorefresh results list on copy job details.